### PR TITLE
fix: update make return type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yawaramin/prometo",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "scripts": {
     "clean": "bsb -clean-world",
     "build": "bsb -make-world",

--- a/src/Yawaramin__Prometo.rei
+++ b/src/Yawaramin__Prometo.rei
@@ -40,7 +40,7 @@ let fromArray: array(t('a, 'e)) => t(array('a), 'e);
 let fromPromise: Js.Promise.t('a) => t('a, _);
 
 /** [make(a)] returns a promise which contains the successful result [a]. */
-let make: 'a => t('a, error);
+let make: 'a => t('a, [> error ]);
 
 [@text {|{1 Processing promises}|}];
 


### PR DESCRIPTION
This allows using `make` in a branch where another branch returns `Error.make(polyvar)`.